### PR TITLE
feat(facebook.media): add `page.future` param option

### DIFF
--- a/schemas/facebook.media.list.json
+++ b/schemas/facebook.media.list.json
@@ -30,6 +30,10 @@
           "minimum": 1,
           "default": 20,
           "description": "Number of results"
+        },
+        "future": {
+          "type": "boolean",
+          "description": "Include posts to be posted in the future"
         }
       }
     },

--- a/src/services/storage/facebook-media.js
+++ b/src/services/storage/facebook-media.js
@@ -21,6 +21,10 @@ class FacebookMedia {
       query.where('created_time', cursorDirection, page.cursor);
     }
 
+    if (page.future !== true) {
+      query.where('created_time', '<', (new Date()).toISOString());
+    }
+
     return query.select();
   }
 


### PR DESCRIPTION
BREAKING CHANGE: `facebook.media.list` endpoint will not return posts
scheduled for future unless `page.future` option is specified explicitly