### PR TITLE
feat(twitter): add additional props to serialized tweet

### DIFF
--- a/src/services/twitter.js
+++ b/src/services/twitter.js
@@ -125,9 +125,13 @@ class Twitter {
       account: data.user.screen_name,
       account_id: data.user.id_str,
       account_image: data.user.profile_image_url_https,
+      account_name: data.user.name,
+      account_verified: data.user.verified,
       entities: data.entities,
       extended_entities: data.extended_entities,
       retweeted_status: data.retweeted_status && Twitter.serializeTweet(data.retweeted_status, true),
+      retweet_count: data.retweet_count,
+      favorite_count: data.favorite_count,
     };
 
     tweet.meta = noSerialize !== true

--- a/test/suites/01.twitter.js
+++ b/test/suites/01.twitter.js
@@ -217,7 +217,14 @@ describe('twitter', function testSuite() {
     assert(data);
     assert.strictEqual(data.id, payload.oneTweet.tweetId);
     assert.strictEqual(data.type, 'tweet');
-    assert.strictEqual(data.attributes.text, 'just setting up my twttr');
+    const { text, meta } = data.attributes;
+    assert.strictEqual(text, 'just setting up my twttr');
+    assert(meta.account_id, '12');
+    assert(meta.account);
+    assert(meta.account_name);
+    assert(meta.account_verified);
+    assert(meta.retweet_count);
+    assert(meta.favorite_count);
   });
 
   after('close consumer', () => listener.close());


### PR DESCRIPTION
Added  `account_name, account_verified, retweet_count, favorite_count`

The resulted tweet with new added properties:
```
  date: 'Tue Mar 21 20:50:14 +0000 2006',
  text: 'just setting up my twttr',
  meta: {
    id_str: '20',
    account: 'jack',
    entities: { urls: [], symbols: [], hashtags: [], user_mentions: [] },
    account_id: '12',
    account_name: 'jack⚡️',
    account_image: 'https://pbs.twimg.com/profile_images/1115644092329758721/AFjOr-K8_normal.jpg',
    retweet_count: 121680,
    favorite_count: 173041,
    account_verified: true
  },
  account: 'jack'
  ```