### PR TITLE
fix: handle response for undefined model

### DIFF
--- a/src/utils/response.js
+++ b/src/utils/response.js
@@ -42,7 +42,7 @@ function collectionResponse(objects, type, options = {}) {
 
 function modelResponse(model, type) {
   const response = {
-    data: model !== null ? transform(model, type) : null,
+    data: model != null && typeof model === 'object' ? transform(model, type) : null,
   };
 
   return response;

--- a/test/suites/01.twitter.js
+++ b/test/suites/01.twitter.js
@@ -283,6 +283,11 @@ describe('twitter', function testSuite() {
     });
   });
 
+  it('responds with null if tweet model not found', async () => {
+    const { data } = await service.amqp.publishAndWait(uri.getOne, payload.nonExistentTweet);
+    assert.strictEqual(data, null);
+  });
+
   it('get one tweet by id', async () => {
     const { data } = await service.amqp.publishAndWait(uri.getOne, payload.oneTweet);
     assert(data);


### PR DESCRIPTION
Error:
`"message":"Cannot read properties of undefined (reading 'id')","stack":"TypeError: Cannot read properties of undefined (reading 'id')\n    at transform (/src/src/utils/response.js:11:16)\n    at modelResponse (/src/src/utils/response.js:45:28)\n    at /src/src/actions/tweet.get.js:15:22\n`